### PR TITLE
fix: file/folder separator compatibility

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -543,7 +543,9 @@ impl AudioFile {
     fn pascal_case(&self) -> String {
         let mut parts: Vec<String> = self
             .path
-            .split(|c: char| c.is_whitespace() || "-_.\\".contains(c))
+            .split(|c: char| {
+                c.is_whitespace() || "-_.".contains(c) || c == std::path::MAIN_SEPARATOR
+            })
             .filter(|s| !s.is_empty())
             .map(|s| {
                 let mut chars = s.chars();

--- a/examples/event_options.rs
+++ b/examples/event_options.rs
@@ -67,7 +67,7 @@ fn set_channel_settings(mut ew: EventWriter<SettingsEvent<SfxChannel>>) {
     // Set the playback settings for a specific track in the channel
     let track_settings_event = SfxChannel::settings_event()
         .with_settings(PlaybackSettings::LOOP)
-        .with_track(AudioFiles::BackgroundOGG);
+        .with_track(AudioFiles::MusicBackgroundOGG);
 
     ew.send_batch(vec![
         vol_event,

--- a/examples/volume.rs
+++ b/examples/volume.rs
@@ -117,7 +117,8 @@ fn setup(mut commands: Commands, mut ew: EventWriter<PlayEvent<MusicChannel>>) {
 
     // Adjusting Music & Global will affect this sound
     ew.send(
-        MusicChannel::play_event(AudioFiles::BackgroundOGG).with_settings(PlaybackSettings::LOOP),
+        MusicChannel::play_event(AudioFiles::MusicBackgroundOGG)
+            .with_settings(PlaybackSettings::LOOP),
     );
 }
 


### PR DESCRIPTION
This fixes an issue that arose from me writing this on Windows and not realizing it wasn't platform agnostic, which could result in the generated struct names having a `/` in it if being built on a non-Windows platform. To ensure compatibility, I've moved one of the assets used in the examples to a subfolder.