### PR TITLE
Add f32 in format! to ensure duration is type f32

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -534,7 +534,7 @@ impl AudioFile {
         format!(
             "const {}: AudioFile = AudioFile {{
             path: {:?},
-            duration: {},
+            duration: {}f32,
         }};",
             self.snake_case().to_uppercase(),
             self.path,


### PR DESCRIPTION
We could also use something like `format!("{:.2}", self.duration)`, but it may cut off decimal places and I don't see a situation where tacking f32 on the end wouldn't work.

Fixes #5 